### PR TITLE
Make the navbar work in collapsed mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   	<script src="js/vendor/angular-route.min.js"></script>
   	<script src="js/vendor/jquery-1.11.3.min.js"></script>
   	<script src="js/vendor/bootstrap.min.js"></script>
-    <script src="js/vendor/bootstrap.js"></script>
     <script src="js/vendor/aslider.js"></script>
   </head>
 

--- a/templates/music.html
+++ b/templates/music.html
@@ -6,19 +6,18 @@
 		<ol class="carousel-indicators">
 			<li data-target="#carousel" data-slide-to="0" class="active"></li>
 			<li data-target="#carousel" data-slide-to="1"></li>
-			<li data-target="#carousel" data-slide-to="2"></li>
-			<li data-target="#carousel" data-slide-to="3"></li>
 		</ol>
 
-		<div class="carousel-innter" role="listbox">
+		<div class="carousel-inner" role="listbox">
 			<div class="item active">
 				<img class="img-responsive center-block" src="media/img/party-slide.jpg" alt="party slide" />
 			</div>
 			<div class="item">
-				<img src="img-responsive center-block" src="media/img/nostalgic-slide.jpg" alt="nostalgic slide" />
+				<img class="img-responsive center-block" src="media/img/nostalgic-slide.jpg" alt="nostalgic slide" />
 			</div>
 		</div>
 
+		<!-- Left and right controls -->
 		<a class="left carousel-control" href="#carousel" role="button" data-slide="prev">
 			<span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
 			<span class="sr-only">Previous</span>
@@ -27,6 +26,7 @@
 			<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
 			<span class="sr-only">Next</span>
 		</a>
+
 	</div>
 
 </div>

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -12,7 +12,7 @@
 			<a class="navbar-brand page-scroll" href="#page-top">The Monkees</a>
 		</div>
 	
-		<div class="collapse navbar-collapse" id="#navbar-collapse">
+		<div class="collapse navbar-collapse" id="navbar-collapse">
 			<ul class="nav navbar-nav navbar-right">
 				<li>
 					<a class="page-scroll" href="#/music">The Music</a>


### PR DESCRIPTION
The problem was simply that your navbar-collapse element had the id specified as 'id="#navabar-collapse", but you meant it without the hash symbol.

Additionally index.html was including both bootstrap.js and bootstrap.min.js but these are the same. The 'min' just refers to minimising the source code. What it does is turn Javascript which is readable for humans, into Javascript that does not have long variable names or include any whitespace. This makes it completely unreadable for humans, but also less to download. So when you have it on a web page often you want the minimised version because you want it to download quickly and you don't particularly want your users to be able to read the Javascript since they can go get the official bootstrap.js if they are really interested.

Hope this helps.
