### PR TITLE
Make the iTunesSearch directive visible by making the element tag all…

### DIFF
--- a/js/directive.js
+++ b/js/directive.js
@@ -12,7 +12,7 @@ bandApp.directive("blackfooter", function() {
 	};
 });
 
-bandApp.directive("iTunesSearch", function() {
+bandApp.directive("itunessearch", function() {
 	return {
 		templateUrl: "templates/directives/iTunesSearch.html",
 		restrict: "E",

--- a/templates/music.html
+++ b/templates/music.html
@@ -39,7 +39,7 @@
 
 	<p>The Monkees' first album in nearly 20 years is also their best since the Sixties – to be precise, since the Head soundtrack in 1968. (Sorry, Instant Replay diehards.) It's a labor of love – not just for the three surviving lads, but for all the Monkeemaniacs pitching in, headed by producer Adam Schlesinger (from Ivy and Fountains of Wayne), who contributes the gem "Our Own World." It nails the classic summer-jangle Monkees sound, with seriously fantastic new tunes from Rivers Cuomo, Andy Partridge and the none-more-mod squad of Noel Gallagher and Paul Weller. Micky Dolenz, Mike Nesmith and the mighty Peter Tork are all in top shape–their voices have aged as handsomely as they have. When they harmonize on Ben Gibbard's wistful folkie lament "Me & Magdalena," it's a miraculously gorgeous moment of time-travel mind-warp. "Little Girl" is pure uncut Torkmanship. And as a last word from the late Davy Jones, there's his version of the Neil Diamond nugget "Love to Love." Monkees freaks have waited far too long for this album. But it was worth it.</p> -->
 
-	<iTunesSearch></iTunesSearch>
+	<itunessearch></itunessearch>
 
 </div> 
 <blackfooter></blackfooter>


### PR DESCRIPTION
… lower case letters.

I'm not sure this entirely fixes everything, but it at least makes your search bar visible. I have to say it's a bit of an obscure error, since it wasn't like you had different cases in your HTML and your directive.js.
