### PR TITLE
Move the itunessearch element inside the navigationbar, this will mea…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -253,14 +253,6 @@
 	height:500px;
 }
 
-iTunesSearch {
-	position:relative;
-	left:200px;
-	border:2px solid red;
-}
-
-
-
 
 /*BOOK PAGE STYLE*/
 .book .page {

--- a/templates/directives/nav.html
+++ b/templates/directives/nav.html
@@ -11,7 +11,8 @@
 	
 			<a class="navbar-brand page-scroll" href="#page-top">The Monkees</a>
 		</div>
-	
+		<itunessearch></itunessearch>
+
 		<div class="collapse navbar-collapse" id="navbar-collapse">
 			<ul class="nav navbar-nav navbar-right">
 				<li>

--- a/templates/music.html
+++ b/templates/music.html
@@ -39,7 +39,6 @@
 
 	<p>The Monkees' first album in nearly 20 years is also their best since the Sixties – to be precise, since the Head soundtrack in 1968. (Sorry, Instant Replay diehards.) It's a labor of love – not just for the three surviving lads, but for all the Monkeemaniacs pitching in, headed by producer Adam Schlesinger (from Ivy and Fountains of Wayne), who contributes the gem "Our Own World." It nails the classic summer-jangle Monkees sound, with seriously fantastic new tunes from Rivers Cuomo, Andy Partridge and the none-more-mod squad of Noel Gallagher and Paul Weller. Micky Dolenz, Mike Nesmith and the mighty Peter Tork are all in top shape–their voices have aged as handsomely as they have. When they harmonize on Ben Gibbard's wistful folkie lament "Me & Magdalena," it's a miraculously gorgeous moment of time-travel mind-warp. "Little Girl" is pure uncut Torkmanship. And as a last word from the late Davy Jones, there's his version of the Neil Diamond nugget "Love to Love." Monkees freaks have waited far too long for this album. But it was worth it.</p> -->
 
-	<itunessearch></itunessearch>
 
 </div> 
 <blackfooter></blackfooter>


### PR DESCRIPTION
…n it will display in the correct place, be part of the navigation bar and not be disabled.

I think this makes more sense than trying to move it around relative to where it should be. You could also consider having it part of the collapsible navbar elements.
